### PR TITLE
Skip updating bitstrings for diagonal gates

### DIFF
--- a/bgls/simulator.py
+++ b/bgls/simulator.py
@@ -160,6 +160,11 @@ class Simulator(cirq.SimulatesSamples):
 
             self._apply_gate(op, state)
 
+            # Skip updating bitstrings for diagonal gates since they do not change
+            # the probability distribution.
+            if cirq.is_diagonal(cirq.unitary(op.gate), atol=1e-8):
+                continue
+
             # Determine the candidate bitstrings to sample.
             op_support = {qubit_index[q] for q in op.qubits}
             candidates_list = []


### PR DESCRIPTION
...since they don't change the probability distribution.

Speeds up tests by ~20 seconds on my machine. We should be profiling but it's fine for now