### PR TITLE
Memoize computing probabilities in parallel sampling

### DIFF
--- a/bgls/simulator.py
+++ b/bgls/simulator.py
@@ -166,7 +166,7 @@ class Simulator(cirq.SimulatesSamples):
             candidate_probs_list = []
 
             # Memoize self._compute_probability.
-            computed_probabilities: Dict[str:float] = {}
+            computed_probabilities: Dict[str, float] = {}
 
             def compute_probability(wavefunction, bstring):
                 if bstring in computed_probabilities.keys():

--- a/bgls/simulator.py
+++ b/bgls/simulator.py
@@ -166,7 +166,8 @@ class Simulator(cirq.SimulatesSamples):
             candidate_probs_list = []
 
             # Memoize self._compute_probability.
-            computed_probabilities: Dict[str: float] = {}
+            computed_probabilities: Dict[str:float] = {}
+
             def compute_probability(wavefunction, bstring):
                 if bstring in computed_probabilities.keys():
                     return computed_probabilities[bstring]

--- a/bgls/simulator.py
+++ b/bgls/simulator.py
@@ -168,7 +168,9 @@ class Simulator(cirq.SimulatesSamples):
             # Memoize self._compute_probability.
             computed_probabilities: Dict[str, float] = {}
 
-            def compute_probability(wavefunction: State, bstring: str) -> float:
+            def compute_probability(
+                wavefunction: State, bstring: str
+            ) -> float:
                 if bstring in computed_probabilities.keys():
                     return computed_probabilities[bstring]
                 probability = self._compute_probability(wavefunction, bstring)

--- a/bgls/simulator.py
+++ b/bgls/simulator.py
@@ -100,7 +100,7 @@ class Simulator(cirq.SimulatesSamples):
         """
         records: Dict[str, np.ndarray] = {}
         keys_to_bitstrings_list = []
-        if needs_trajectories(self._apply_gate, circuit):
+        if not needs_trajectories(self._apply_gate, circuit):
             keys_to_bitstrings_list = self._perform_bgls_sampling(
                 circuit, repetitions
             )
@@ -160,11 +160,21 @@ class Simulator(cirq.SimulatesSamples):
 
             self._apply_gate(op, state)
 
-            # Determine the candidate bitstrings to sample.
+            # Update bits on support of this operation.
             op_support = {qubit_index[q] for q in op.qubits}
             candidates_list = []
-            joined_cands_list = []
             candidate_probs_list = []
+
+            # Memoize self._compute_probability.
+            computed_probabilities: Dict[str: float] = {}
+            def compute_probability(wavefunction, bstring):
+                if bstring in computed_probabilities.keys():
+                    return computed_probabilities[bstring]
+                probability = self._compute_probability(wavefunction, bstring)
+                computed_probabilities[bstring] = probability
+                return probability
+
+            # Compute probabilities for all bitstrings.
             for bitstr in bitstrings:
                 candidates = list(
                     itertools.product(
@@ -175,13 +185,12 @@ class Simulator(cirq.SimulatesSamples):
                     )
                 )
                 candidates_list.append(candidates)
-                joined_cands = ["".join(cand) for cand in candidates]
-                joined_cands_list.append(joined_cands)
+
                 # Compute probability of each candidate bitstring.
                 candidate_probs = np.asarray(
                     [
-                        self._compute_probability(state, candidate)
-                        for candidate in joined_cands
+                        compute_probability(state, "".join(candidate))
+                        for candidate in candidates
                     ]
                 )
                 candidate_probs_list.append(candidate_probs)

--- a/bgls/simulator.py
+++ b/bgls/simulator.py
@@ -168,7 +168,7 @@ class Simulator(cirq.SimulatesSamples):
             # Memoize self._compute_probability.
             computed_probabilities: Dict[str, float] = {}
 
-            def compute_probability(wavefunction, bstring):
+            def compute_probability(wavefunction: State, bstring: str) -> float:
                 if bstring in computed_probabilities.keys():
                     return computed_probabilities[bstring]
                 probability = self._compute_probability(wavefunction, bstring)

--- a/bgls/simulator.py
+++ b/bgls/simulator.py
@@ -159,7 +159,7 @@ class Simulator(cirq.SimulatesSamples):
                 continue
 
             self._apply_gate(op, state)
-    
+
             # Skip updating bitstrings for diagonal gates since they do not change
             # the probability distribution.
             if cirq.is_diagonal(cirq.unitary(op.gate), atol=1e-8):


### PR DESCRIPTION
Gives a pretty good speedup. Unit tests reduced to about 13 seconds on my machine (compared to about 70 seconds before), and see the following timing benchmark on sampling 1000 bitstrings from 8-qubit random circuits of varying depths. ("With optimization" = merging ops, to be added in a future PR.)

## Before memoization (current main branch)

![output-main](https://github.com/asciineuron/bgls/assets/32416820/d20ee365-f569-40bf-9858-63a9d0d2c193)

## After memoization (this PR)
![output](https://github.com/asciineuron/bgls/assets/32416820/48c2addb-aac1-403b-aefa-f50ce34091e0)

Should be able to speedup further with parallelization etc.

This PR also fixes a bug on when to use parallel sampling and removes a few unused / unnecessary variables.