### PR TITLE
Update bitstrings in parallel

### DIFF
--- a/bgls/simulator.py
+++ b/bgls/simulator.py
@@ -196,10 +196,12 @@ class Simulator(cirq.SimulatesSamples):
                 )
 
                 # Compute probability of each candidate bitstring.
-                probabilities = np.array([
-                    compute_probability(state, "".join(candidate))
-                    for candidate in candidates
-                ])
+                probabilities = np.array(
+                    [
+                        compute_probability(state, "".join(candidate))
+                        for candidate in candidates
+                    ]
+                )
 
                 # Sample new bitstring(s).
                 new_bitstring_indices = self._rng.choice(

--- a/bgls/simulator.py
+++ b/bgls/simulator.py
@@ -183,7 +183,7 @@ class Simulator(cirq.SimulatesSamples):
                 return probability
 
             # Update bits on support of this operation.
-            new_bitstrings = collections.defaultdict(int)
+            new_bitstrings: Dict[str, int] = collections.defaultdict(int)
             op_support = {qubit_index[q] for q in op.qubits}
             for bitstring, count in bitstrings.items():
                 candidates = list(
@@ -196,10 +196,10 @@ class Simulator(cirq.SimulatesSamples):
                 )
 
                 # Compute probability of each candidate bitstring.
-                probabilities = [
+                probabilities = np.array([
                     compute_probability(state, "".join(candidate))
                     for candidate in candidates
-                ]
+                ])
 
                 # Sample new bitstring(s).
                 new_bitstring_indices = self._rng.choice(


### PR DESCRIPTION
Stores multiplicities of bitstrings instead of a list of all bitstrings, and correspondingly updates how bitstrings are resampled. Gives a large speedup in most cases, e.g. for sampling from 8-qubit, depth 20 circuits as shown below.

Current main branch:

![time_to_sample_vs_repetitions_n_8_d_20_old_for_pr](https://github.com/asciineuron/bgls/assets/32416820/f18c0ad3-7e46-4bdc-a4e7-249b0a656619)

This PR:

![time_to_sample_vs_repetitions_n_8_d_20_new_for_pr](https://github.com/asciineuron/bgls/assets/32416820/8e070214-143b-4fea-a547-0d6dbb2b36db)

Note: I think there is a better way to prepare the samples to be converted to a cirq.Result than unflattening the dict.

<details>
  <summary>Benchmark for above plots</summary>
  
```python
import time

import cirq
import matplotlib.pyplot as plt
import numpy as np
from tqdm import tqdm

import bgls

nqubits = 8
depth = 20
repetitions = np.linspace(1, 10_000, 50, dtype=int)
trials = 4

qubits = cirq.LineQubit.range(nqubits)

circuit = cirq.testing.random_circuit(qubits, depth, 1) + cirq.measure(qubits)

simulator = bgls.Simulator(
    initial_state=cirq.StateVectorSimulationState(qubits=qubits, initial_state=0),
    apply_gate=cirq.protocols.act_on,
    compute_probability=bgls.utils.cirq_state_vector_bitstring_probability,
)

all_times = []

for t in tqdm(range(trials), desc="Trial"):
    times = []

    for nreps in repetitions:
        start = time.monotonic()
        _ = simulator.run(circuit, repetitions=nreps)
        times.append(time.monotonic() - start)
    all_times.append(times)

times = np.average(all_times, axis=0)
times_std = np.std(all_times, axis=0, ddof=1)

plt.errorbar(repetitions, times, yerr=times_std, capsize=10)

plt.ylabel(f"Time to sample {nqubits}-qubit, depth {depth} circuit (seconds)")
plt.xlabel(f"Repetitions")

plt.show();
```
</details>