### PR TITLE
Update supported Python versions and CI behavior

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-# Description

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.10, 3.11]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,15 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Pytest
+name: Build
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      main
+  push:
+    branches:
+      main
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@
 
 name: Pytest
 
-on: [ push, pull_request ]
+on: [pull_request]
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [3.9, 3.10, 3.11]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -1,6 +1,12 @@
 name: Doctest
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      main
+  push:
+    branches:
+      main
 
 jobs:
   build:

--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -1,6 +1,6 @@
 name: Doctest
 
-on: [ push, pull_request ]
+on: [pull_request]
 
 jobs:
   build:
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.9 ]
+        python-version: [3.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,6 @@
 name: Format
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   check-format:
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # bgls
 
-[![build](https://github.com/asciineuron/bgls/workflows/Python%20package/badge.svg)](https://github.com/asciineuron/bgls/actions)
+[![build](https://github.com/asciineuron/bgls/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/asciineuron/bgls/actions)
+[![doctest](https://github.com/asciineuron/bgls/actions/workflows/doctest.yml/badge.svg?branch=main)](https://github.com/asciineuron/bgls/actions)
 [![Repository](https://img.shields.io/badge/GitHub-5C5C5C.svg?logo=github)](https://github.com/asciineuron/bgls)
 
 bgls is a cirq-interfacing implementation of the gate-by-gate quantum sampling

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "Documentation": "https://github.com/asciineuron/bgls",
         "Source": "https://github.com/asciineuron/bgls",
     },
-    python_requires=">=3.7",
+    python_requires=">=3.9.0",
 )
 
 # Restore _version.py to its previous state.


### PR DESCRIPTION
Update supported Python versions and only trigger CI on PRs and push to main. NB: Can always open a WIP PR to trigger CI.