### PR TITLE
Install BGLS in Sphinx build workflow to fix import errors in docs

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -13,6 +13,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
           python -m pip install -r dev_requirements.txt
+          python -m pip install .
       - name: Build HTML
         working-directory: ./docs
         run: |


### PR DESCRIPTION
Docs pages currently show

![image](https://github.com/asciineuron/bgls/assets/32416820/62570a08-d00a-4b60-bf23-5bda5df67b9b)

I believe because the Sphinx build workflow does not install BGLS, so adding this line in this PR.