### PR TITLE
Add latex extension to sphinx.

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -10,6 +10,7 @@ mypy
 
 # Documentation.
 sphinx
+sphinx-toolbox
 myst-nb
 furo
 quimb

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project
 # -information
 
-project = 'bgls'
+project = 'BGLS'
 copyright = '2023, Alex Shapiro, Ryan LaRose'
 author = 'Alex Shapiro, Ryan LaRose'
 
@@ -19,7 +19,7 @@ author = 'Alex Shapiro, Ryan LaRose'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general
 # -configuration
 
-extensions = ['sphinx.ext.autodoc', 'myst_nb']
+extensions = ['sphinx.ext.autodoc', 'myst_nb', 'sphinx_toolbox.latex']
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']


### PR DESCRIPTION
Latex is not currently rendering in the docs, e.g.

![image](https://github.com/asciineuron/bgls/assets/32416820/c215f225-fd2b-48cf-bd2f-5fe5a5b40533)
