### PR TITLE
Add stochastic/noisy act_on replacement for state vectors

### DIFF
--- a/bgls/apply.py
+++ b/bgls/apply.py
@@ -18,6 +18,8 @@ import cirq
 
 import bgls
 
+from typing import Optional, cast, Sequence
+
 
 def act_on_near_clifford(
     op: cirq.Operation,
@@ -59,3 +61,114 @@ def act_on_near_clifford(
             "Operation must be Clifford, T, or a z rotation. Was called on "
             "the gate " + str(op.gate) + "."
         )
+
+
+def _to_unchecked_state_vector(
+    state_rep: "cirq.STATE_VECTOR_LIKE",
+    num_qubits: Optional[int] = None,
+    *,  # Force keyword arguments
+    qid_shape: Optional[Sequence[int]] = None,
+    dtype: Optional["DTypeLike"] = None,
+    atol: float = 1e-7,
+) -> np.ndarray:
+    """Derived from cirq.to_valid_state_vector. Converts the state_rep to
+    ndarray form. Notably does not check validity, for use with non-unitary
+    noise gates
+
+    This method is used to support passing in an integer representing a
+    computational basis state or a full state vector as a representation of
+    a pure state.
+
+    Args:
+        state_rep: If an int, the state vector returned is the state vector
+            corresponding to a computational basis state. If a numpy array
+            this is the full state vector.
+        num_qubits: The number of qubits for the state vector. The state_rep
+            must be valid for this number of qubits.
+        qid_shape: The expected qid shape of the state vector. Specify this
+            argument when using qudits.
+        dtype: The numpy dtype of the state vector, will be used when creating
+            the state for a computational basis state, or validated against if
+            state_rep is a numpy array.
+        atol: Numerical tolerance for verifying that the norm of the state
+            vector is close to 1.
+
+    Returns:
+        A numpy ndarray corresponding to the state vector on the given
+        number of
+        qubits.
+
+    Raises:
+        ValueError: if num_qubits != len(qid_shape).
+    """
+    if isinstance(state_rep, cirq.value.ProductState):
+        num_qubits = len(state_rep)
+
+    # Check shape.
+    if num_qubits is None and qid_shape is None:
+        try:
+            qid_shape = cirq.qis.states.infer_qid_shape(state_rep)
+        except:
+            raise ValueError(
+                "Failed to infer the qid shape of the given state. "
+                "Please specify the qid shape explicitly using either the "
+                "`num_qubits` or `qid_shape` argument."
+            )
+    if qid_shape is None:
+        qid_shape = (2,) * cast(int, num_qubits)
+    else:
+        qid_shape = tuple(qid_shape)
+    if num_qubits is None:
+        num_qubits = len(qid_shape)
+    if num_qubits != len(qid_shape):
+        raise ValueError(
+            f"num_qubits != len(qid_shape). num_qubits is <{num_qubits!r}>. "
+            f"qid_shape is <{qid_shape!r}>."
+        )
+
+    if isinstance(state_rep, np.ndarray):
+        state_rep = np.copy(state_rep)
+    state = cirq.quantum_state(
+        state_rep, qid_shape, validate=False, dtype=dtype, atol=atol
+    )
+    return cast(np.ndarray, state.state_vector())
+
+
+def act_on_noisy_state_vector(
+    op: cirq.Operation,
+    state: cirq.sim.state_vector_simulation_state.StateVectorSimulationState,
+    rng: np.random.RandomState = np.random.RandomState(),
+) -> None:
+    # This follows eg Nielsen and Chuang eq 2.93 pg 85
+    # Applies all possible Kraus operators and computes resulting probs
+    # then samples a resultant state and renormalizes it
+    # TODO for now only 1 qubit gates, cirq.MatrixGate limits this
+    # TODO for now limit to state vector since need to calc <psi|M+M|psi>
+
+    num_qubits = len(state.qubits)
+    if not (cirq.is_measurement(op) or cirq.has_unitary(op)):
+        kraus_tuple = cirq.protocols.kraus(op)
+        kraus_ops = []
+        for mat in kraus_tuple:
+            matop = cirq.ops.matrix_gates.MatrixGate(
+                mat, unitary_check=False
+            ).on(op.qubits[0])
+            kraus_ops.append(matop)
+
+        probs = []
+        for gate in kraus_ops:
+            tmpst = state.copy()
+            cirq.protocols.act_on(gate, tmpst)
+            stvec = _to_unchecked_state_vector(
+                tmpst.target_tensor, num_qubits=num_qubits
+            )
+            probs.append(np.abs(np.vdot(stvec, stvec)))
+        probs = np.asarray(probs)
+
+        # sample one of the kraus gates and apply it
+        idx = rng.choice(a=len(kraus_ops), p=probs / sum(probs))
+        cirq.protocols.act_on(kraus_ops[idx], state)
+        # renormalize the state vector
+        state._state._state_vector /= np.sqrt(probs[idx])
+    else:
+        cirq.protocols.act_on(op, state)

--- a/bgls/simulator_test.py
+++ b/bgls/simulator_test.py
@@ -390,41 +390,6 @@ def test_intermediate_measurements_are_ignored():
     assert results1 == results2
 
 
-@pytest.mark.parametrize("channel", (cirq.depolarize, cirq.amplitude_damp))
-def test_simulate_with_noise_common_single_qubit_channels(channel):
-    """Tests correctness of simulating noisy circuits with
-    common single-qubit channels.
-    """
-    qubits = cirq.LineQubit.range(2)
-
-    circuit = cirq.testing.random_circuit(qubits, n_moments=3, op_density=1)
-    circuit = circuit.with_noise(channel(0.01))
-
-    sim = bgls.Simulator(
-        initial_state=cirq.StateVectorSimulationState(
-            qubits=qubits, initial_state=0
-        ),
-        apply_op=cirq.protocols.act_on,
-        compute_probability=bgls.born.compute_probability_state_vector,
-    )
-    sim_cirq = cirq.Simulator()
-
-    # Test expectation of observables match Cirq.Simulator.
-    observables = [cirq.X.on(qubits[0]), cirq.Z.on(qubits[1])]
-
-    values = sim.sample_expectation_values(
-        circuit,
-        observables=observables,
-        num_samples=2048,
-    )
-    values_cirq = sim_cirq.sample_expectation_values(
-        circuit,
-        observables=observables,
-        num_samples=2048,
-    )
-    assert np.allclose(values, values_cirq, atol=1e-1)
-
-
 def test_simulate_with_custom_noise_channel():
     """Tests correctness of simulating circuits with custom
     noise channels.


### PR DESCRIPTION
@rmlarose this could be interesting, let me know what you think.

Our problem with noisy simulation is cirq doesn't handle it right for state vectors. Their `cirq.Simulator` can do stochastic sampling but this is at the simulator level somewhere, rather than `act_on`.

I implemented here this stochastic technique with act on. It basically decomposes any noise channel into its kraus operators. We can turn these into (non-unitary) gates, apply each to a copy of our state vector state, and compute the corresponding probabilities. We then sample one of these as our return value and renormalize the state vector.

Basically the same procedure under the hood as measurement operators but with the kraus decomposition.

<img width="568" alt="quantum-measurement" src="https://github.com/asciineuron/bgls/assets/32694710/734da629-6725-4c0c-80bb-9a3a75011a92">
