### PR TITLE
Use Python 3.11

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "Documentation": "https://github.com/asciineuron/bgls",
         "Source": "https://github.com/asciineuron/bgls",
     },
-    python_requires=">=3.9.0",
+    python_requires=">=3.9.0, <3.12",
 )
 
 # Restore _version.py to its previous state.


### PR DESCRIPTION
Numba (used by quimb) doesn't support Python 3.12.0, which is why #52 was occurring. Have modified the Python version to 3.11 now.